### PR TITLE
dokku static site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "valueflo.ws",
+  "private": true,
+  "description": "valueflo.ws website",
+  "main": "server.js",
+  "scripts": {
+    "test": "true",
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/valueflows/valueflo.ws.git"
+  },
+  "author": "Value Flows",
+  "license": "",
+  "bugs": {
+    "url": "https://github.com/valueflows/valueflo.ws/issues"
+  },
+  "homepage": "https://github.com/valueflows/valueflo.ws#readme",
+  "dependencies": {
+    "finalhandler": "^0.4.0",
+    "serve-static": "^1.10.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "server.js",
   "scripts": {
     "test": "true",
-    "start": "node server.js"
+    "start": "node server.js",
+    "deploy-remote": "git remote add dokku dokku@valueflo.ws:valueflo.ws",
+    "deploy-push": "git push dokku master",
+    "deploy": "npm run deploy-remote; npm run deploy-push"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,12 @@
+var finalhandler = require('finalhandler')
+var http = require('http')
+var serveStatic = require('serve-static')
+ 
+var serve = serveStatic(__dirname)
+ 
+var server = http.createServer(function(req, res){
+  var done = finalhandler(req, res)
+  serve(req, res, done)
+})
+ 
+server.listen(process.env.PORT || 3000)


### PR DESCRIPTION
how i closed #6 
- adds `npm start` script: basic static http server with [`serve-static`](https://www.npmjs.com/package/serve-static)
- adds `npm run deploy` script: deploys to a [dokku](http://progrium.viewdocs.io/dokku/) i setup at https://valueflo.ws

happy to give out keys @valueflows/owners, mail me your ssh pubs. also looking to automate the deploy, as suggested.
